### PR TITLE
fixed namespace typo

### DIFF
--- a/Plugin/Block/Widget/Button/Toolbar.php
+++ b/Plugin/Block/Widget/Button/Toolbar.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Payu\PaymentGateway\Plugin\Block\Widget\Button;
+namespace PayU\PaymentGateway\Plugin\Block\Widget\Button;
 
 use Magento\Backend\Block\Widget\Button\Toolbar as ToolbarContext;
 use Magento\Framework\View\Element\AbstractBlock;


### PR DESCRIPTION
In Toolbar plugin class there is namespace with different U case in package name. This is causing issues when using composer authoritative class map (https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-a-authoritative-class-maps) is used.